### PR TITLE
Fixes for later version of pdftotext

### DIFF
--- a/capital-budget.js
+++ b/capital-budget.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const { reader, writer } = require('./util/io')
-const { matchPattern, trimSubstring } = require('./util/line')
+const { trimLine, matchPattern, trimSubstring } = require('./util/line')
 const { formatCost, parseCostAndAssign } = require('./util/format')
 
 const { BUDGETLINE_ID_PATTERN } = require('./util/patterns')
@@ -106,6 +106,7 @@ const parsePage2Fields = (line) => {
 
 reader(inputPath)
   .on('line', (line) => {
+    line = trimLine(line)
     // start parsing lines page 1
     if (/PRIOR APPROPRIATIONS/.test(line)) {
       startParsingLines = true

--- a/capital-budget.js
+++ b/capital-budget.js
@@ -3,7 +3,7 @@ const { reader, writer } = require('./util/io')
 const { trimLine, matchPattern, trimSubstring } = require('./util/line')
 const { formatCost, parseCostAndAssign } = require('./util/format')
 
-const { BUDGETLINE_ID_PATTERN } = require('./util/patterns')
+const { BUDGETLINE_ID_PATTERN, getFY } = require('./util/patterns')
 
 // grab inputPath, derive outputPath
 const inputPath = process.argv[2]
@@ -11,6 +11,7 @@ const fileName = path.basename(inputPath, '.txt')
 const outputPath = `data/${fileName}.json`
 
 // 0 or 1, representing the two pages that a single budget line appears across
+let fy
 let budgetPage
 let budgetLine
 let startParsingLines = false // toggled when we reach the line prior to the data we want to scrape
@@ -20,6 +21,7 @@ const items = []
 
 const createEmptyBudgetLine = () => {
   return {
+    fy,
     id: '',
     fmsId: '',
     description: '',
@@ -107,6 +109,10 @@ const parsePage2Fields = (line) => {
 reader(inputPath)
   .on('line', (line) => {
     line = trimLine(line)
+    if (!fy) {
+      fy = getFY(line)
+    } 
+
     // start parsing lines page 1
     if (/PRIOR APPROPRIATIONS/.test(line)) {
       startParsingLines = true

--- a/geographic-analysis.js
+++ b/geographic-analysis.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const { reader, writer } = require('./util/io')
-const { matchPattern, trimSubstring } = require('./util/line')
+const { trimLine, matchPattern, trimSubstring } = require('./util/line')
 
 const { BUDGETLINE_ID_PATTERN } = require('./util/patterns')
 
@@ -16,7 +16,10 @@ const items = []
 // fire up a line-by-line reader
 reader(inputPath)
   .on('line', (line) => {
-  // pattern to start parsing
+    
+    line = trimLine(line)
+
+    // pattern to start parsing
     if (/BOROUGH ANALYSIS OF /.test(line)) {
       startParsingLines = true
       return

--- a/geographic-analysis.js
+++ b/geographic-analysis.js
@@ -2,14 +2,16 @@ const path = require('path')
 const { reader, writer } = require('./util/io')
 const { trimLine, matchPattern, trimSubstring } = require('./util/line')
 
-const { BUDGETLINE_ID_PATTERN } = require('./util/patterns')
+const { BUDGETLINE_ID_PATTERN, getFY } = require('./util/patterns')
 
 // grab inputPath, derive outputPath
 const inputPath = process.argv[2]
 const fileName = path.basename(inputPath, '.txt')
 const outputPath = `data/${fileName}-geographic.json`
 
+let fy
 let geography = ''
+
 let startParsingLines = false // toggled when we reach the line prior to the data we want to scrape
 const items = []
 
@@ -18,6 +20,9 @@ reader(inputPath)
   .on('line', (line) => {
     
     line = trimLine(line)
+    if (!fy) {
+      fy = getFY(line)
+    } 
 
     // pattern to start parsing
     if (/BOROUGH ANALYSIS OF /.test(line)) {
@@ -59,6 +64,7 @@ reader(inputPath)
 
         // build an item to push to the array
         const item = {
+          fy,
           id,
           geography
         }

--- a/pdf-to-text.sh
+++ b/pdf-to-text.sh
@@ -3,5 +3,5 @@ mkdir -p txt
 for file in pdf/*; do
   filename=$(basename "${file%.*}")
   echo "$filename"
-  pdftotext -x 35 -y 20 -W 538 -H 1000 -fixed 4.08 -layout "$file" txt/$filename.txt
+  pdftotext -fixed 4.08 -layout "$file" txt/$filename.txt
 done

--- a/rescindments.js
+++ b/rescindments.js
@@ -1,6 +1,6 @@
 const path = require('path')
 const { reader, writer } = require('./util/io')
-const { matchPattern, trimSubstring } = require('./util/line')
+const { trimLine, matchPattern, trimSubstring } = require('./util/line')
 const { formatCost } = require('./util/format')
 
 const { BUDGETLINE_ID_PATTERN, COST_TYPE_PATTERN } = require('./util/patterns')
@@ -41,6 +41,7 @@ const pushItem = () => {
 // fire up a line-by-line reader
 reader(inputPath)
   .on('line', (line) => {
+    line = trimLine(line)
     // start parsing lines once this pattern is found
     if (/AMOUNT RESCINDED/.test(line)) {
       startParsingLines = true

--- a/rescindments.js
+++ b/rescindments.js
@@ -3,13 +3,14 @@ const { reader, writer } = require('./util/io')
 const { trimLine, matchPattern, trimSubstring } = require('./util/line')
 const { formatCost } = require('./util/format')
 
-const { BUDGETLINE_ID_PATTERN, COST_TYPE_PATTERN } = require('./util/patterns')
+const { BUDGETLINE_ID_PATTERN, COST_TYPE_PATTERN, getFY } = require('./util/patterns')
 
 // grab inputPath, derive outputPath
 const inputPath = process.argv[2]
 const fileName = path.basename(inputPath, '.txt')
 const outputPath = `data/${fileName}-rescindments.json`
 
+let fy
 let budgetLineId = ''
 let rescindments = {}
 let startParsingLines = false // toggled when we reach the line prior to the data we want to scrape
@@ -27,6 +28,7 @@ const parseRescindment = (line) => {
 
 const pushItem = () => {
   const item = {
+    fy,
     id: budgetLineId,
     rescindments
   }
@@ -42,6 +44,10 @@ const pushItem = () => {
 reader(inputPath)
   .on('line', (line) => {
     line = trimLine(line)
+    if (!fy) {
+      fy = getFY(line)
+    } 
+
     // start parsing lines once this pattern is found
     if (/AMOUNT RESCINDED/.test(line)) {
       startParsingLines = true

--- a/util/line.js
+++ b/util/line.js
@@ -1,3 +1,10 @@
+// amount of spaces at beginning of each line
+// when converted using pdftotext
+const OFFSET = 9 
+
+const trimLine = (line) => {
+  return line.substring(OFFSET)
+}
 const matchPattern = (start, end, line, pattern) => {
   return trimSubstring(start, end, line).match(pattern)
 }
@@ -8,5 +15,5 @@ const trimSubstring = (start, end, line) => {
 }
 
 module.exports = {
-  matchPattern, trimSubstring
+  trimLine, matchPattern, trimSubstring
 }

--- a/util/patterns.js
+++ b/util/patterns.js
@@ -2,7 +2,15 @@ const BUDGETLINE_ID_PATTERN = /[A-Z]{1,2}-[A-Z0-9]{1,5}/
 
 const COST_TYPE_PATTERN = /([A-Z]{1,3})/
 
+const getFY = (line) => {
+  if (/Fiscal\s+Year\s+20/.test(line)) {
+    return "fy" + line.trim().slice(-2)
+  }
+  return null
+}
+
 module.exports = {
   BUDGETLINE_ID_PATTERN,
-  COST_TYPE_PATTERN
+  COST_TYPE_PATTERN,
+  getFY
 }


### PR DESCRIPTION
newer versions of pdftotext have gotten rid of some params which results in extra spaces being added to the beginning of the line.  this PR corrects for this.

it also fills in the fy field for json data items 